### PR TITLE
Get correct casing for project paths

### DIFF
--- a/src/SlnGen.Build.Tasks.UnitTests/SlnGen.Build.Tasks.UnitTests.csproj
+++ b/src/SlnGen.Build.Tasks.UnitTests/SlnGen.Build.Tasks.UnitTests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="SlnGenTests.cs" />
     <Compile Include="SlnProjectTests.cs" />
     <Compile Include="TestBase.cs" />
+    <Compile Include="ToFullPathInCorrectCaseTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SlnGen.Build.Tasks\SlnGen.Build.Tasks.csproj">

--- a/src/SlnGen.Build.Tasks.UnitTests/ToFullPathInCorrectCaseTests.cs
+++ b/src/SlnGen.Build.Tasks.UnitTests/ToFullPathInCorrectCaseTests.cs
@@ -1,0 +1,42 @@
+﻿using NUnit.Framework;
+using Shouldly;
+using System;
+using System.IO;
+
+namespace SlnGen.Build.Tasks.UnitTests
+{
+    [TestFixture]
+    public class ToFullPathInCorrectCaseTests
+    {
+        [Test]
+        public void IncorrectCaseInDirectory()
+        {
+            ValidatePath(Path.GetTempFileName());
+        }
+
+        [Test]
+        public void IncorrectCaseInFile()
+        {
+            string expectedPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid().ToString("N").ToUpperInvariant()}.txt");
+
+            File.WriteAllText(expectedPath, String.Empty);
+
+            ValidatePath(expectedPath);
+        }
+
+        private void ValidatePath(string expectedPath)
+        {
+            try
+            {
+                expectedPath
+                    .ToLowerInvariant()
+                    .ToFullPathInCorrectCase()
+                    .ShouldBe(expectedPath);
+            }
+            finally
+            {
+                File.Delete(expectedPath);
+            }
+        }
+    }
+}

--- a/src/SlnGen.Build.Tasks/Internal/MSBuildProjectLoader.cs
+++ b/src/SlnGen.Build.Tasks/Internal/MSBuildProjectLoader.cs
@@ -100,7 +100,7 @@ namespace SlnGen.Build.Tasks.Internal
         /// <param name="projectLoadSettings">Specifies the <see cref="ProjectLoadSettings"/> to use when loading projects.</param>
         private void LoadProject(string projectPath, ProjectCollection projectCollection, ProjectLoadSettings projectLoadSettings)
         {
-            if (TryLoadProject(projectPath, projectCollection.DefaultToolsVersion, projectCollection, projectLoadSettings, out var project))
+            if (TryLoadProject(projectPath, projectCollection.DefaultToolsVersion, projectCollection, projectLoadSettings, out Project project))
             {
                 LoadProjectReferences(project, _projectLoadSettings);
             }
@@ -143,9 +143,11 @@ namespace SlnGen.Build.Tasks.Internal
 
             bool shouldLoadProject;
 
+            string fullPath = path.ToFullPathInCorrectCase();
+
             lock (_loadedProjects)
             {
-                shouldLoadProject = _loadedProjects.Add(Path.GetFullPath(path));
+                shouldLoadProject = _loadedProjects.Add(fullPath);
             }
 
             if (!shouldLoadProject)
@@ -157,7 +159,7 @@ namespace SlnGen.Build.Tasks.Internal
 
             try
             {
-                project = new Project(path, null, toolsVersion, projectCollection, projectLoadSettings);
+                project = new Project(fullPath, null, toolsVersion, projectCollection, projectLoadSettings);
             }
             catch (Exception e)
             {

--- a/src/SlnGen.Build.Tasks/Internal/NativeMethods.cs
+++ b/src/SlnGen.Build.Tasks/Internal/NativeMethods.cs
@@ -1,0 +1,23 @@
+﻿using System.Runtime.InteropServices;
+using System.Text;
+
+namespace SlnGen.Build.Tasks.Internal
+{
+    internal static class NativeMethods
+    {
+        /// <summary>
+        /// Converts the specified path to its long form.
+        /// </summary>
+        /// <param name="lpszShortPath">The path to be converted.</param>
+        /// <param name="lpszLongPath">A pointer to the buffer to receive the long path.</param>
+        /// <param name="cchBuffer">The size of the buffer lpszLongPath points to, in TCHARs.</param>
+        /// <returns>If the function succeeds, the return value is the length, in TCHARs, of the string copied to lpszLongPath, not including the terminating null character.
+        /// 
+        /// If the lpBuffer buffer is too small to contain the path, the return value is the size, in TCHARs, of the buffer that is required to hold the path and the terminating null character.
+        /// 
+        /// If the function fails for any other reason, such as if the file does not exist, the return value is zero.To get extended error information, call GetLastError.</returns>
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        [return: MarshalAs(UnmanagedType.U4)]
+        public static extern int GetLongPathName([MarshalAs(UnmanagedType.LPTStr)] string lpszShortPath, [MarshalAs(UnmanagedType.LPTStr)] StringBuilder lpszLongPath, [MarshalAs(UnmanagedType.U4)] int cchBuffer);
+    }
+}


### PR DESCRIPTION
ProjectReference items do not always reflect the casing of a path according to the file system.  When generating a Visual Studio solution, the path casing matters to NuGet.