### PR TITLE
Add support for Solution Items

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,4 +5,8 @@
       <Version>2.0.20-beta</Version>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup>
+    <SlnGenSolutionItem Include="$(MSBuildThisFileDirectory)\Directory.Build.props" />
+  </ItemGroup>
 </Project>

--- a/src/SlnGen.Build.Tasks.UnitTests/MockBuildEngine.cs
+++ b/src/SlnGen.Build.Tasks.UnitTests/MockBuildEngine.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.Build.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace SlnGen.Build.Tasks.UnitTests
+{
+    public class MockBuildEngine : IBuildEngine5
+    {
+        private readonly List<BuildEventArgs> _events = new List<BuildEventArgs>();
+
+        public int ColumnNumberOfTaskNode => 0;
+
+        public bool ContinueOnError => false;
+
+        public IReadOnlyCollection<BuildEventArgs> Events => _events;
+
+        public bool IsRunningMultipleNodes => false;
+
+        public int LineNumberOfTaskNode => 0;
+
+        public string ProjectFileOfTaskNode => null;
+
+        public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs, string toolsVersion)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames, IDictionary[] globalProperties, IDictionary[] targetOutputsPerProject, string[] toolsVersion, bool useResultsCache, bool unloadProjectsOnCompletion)
+        {
+            throw new NotSupportedException();
+        }
+
+        public BuildEngineResult BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames, IDictionary[] globalProperties, IList<string>[] removeGlobalProperties, string[] toolsVersion, bool returnTargetOutputs)
+        {
+            throw new NotSupportedException();
+        }
+
+        public object GetRegisteredTaskObject(object key, RegisteredTaskObjectLifetime lifetime)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void LogCustomEvent(CustomBuildEventArgs e) => _events.Add(e);
+
+        public void LogErrorEvent(BuildErrorEventArgs e) => _events.Add(e);
+
+        public void LogMessageEvent(BuildMessageEventArgs e) => _events.Add(e);
+
+        public void LogTelemetry(string eventName, IDictionary<string, string> properties)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void LogWarningEvent(BuildWarningEventArgs e) => _events.Add(e);
+
+        public void Reacquire()
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RegisterTaskObject(object key, object obj, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection)
+        {
+            throw new NotSupportedException();
+        }
+
+        public object UnregisterTaskObject(object key, RegisteredTaskObjectLifetime lifetime)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Yield()
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/SlnGen.Build.Tasks.UnitTests/SlnGen.Build.Tasks.UnitTests.csproj
+++ b/src/SlnGen.Build.Tasks.UnitTests/SlnGen.Build.Tasks.UnitTests.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ExtensionMethods.cs" />
+    <Compile Include="MockBuildEngine.cs" />
     <Compile Include="MockProject.cs" />
     <Compile Include="MockTaskItem.cs" />
     <Compile Include="SlnFileTests.cs" />

--- a/src/SlnGen.Build.Tasks.UnitTests/SlnGenTests.cs
+++ b/src/SlnGen.Build.Tasks.UnitTests/SlnGenTests.cs
@@ -2,6 +2,8 @@
 using NUnit.Framework;
 using Shouldly;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace SlnGen.Build.Tasks.UnitTests
 {
@@ -54,6 +56,29 @@ namespace SlnGen.Build.Tasks.UnitTests
             };
 
             ValidateParseCustomProjectTypeGuids(customProjectTypeGuids, ".foo", expectedProjectTypeGuid);
+        }
+
+        [Test]
+        public void SolutionItems()
+        {
+            Dictionary<string, string> solutionItems = new Dictionary<string, string>
+            {
+                {"foo", Path.GetFullPath("foo")},
+                {"bar", Path.GetFullPath("bar")}
+            };
+
+            IBuildEngine buildEngine = new MockBuildEngine();
+
+            SlnGen slnGen = new SlnGen
+            {
+                BuildEngine = buildEngine,
+                SolutionItems = solutionItems.Select(i => new MockTaskItem(i.Key)
+                {
+                    {"FullPath", i.Value}
+                }).ToArray<ITaskItem>()
+            };
+
+            slnGen.GetSolutionItems(path => true).ShouldBe(solutionItems.Values);
         }
 
         private static void ValidateParseCustomProjectTypeGuids(string fileExtension, string projectTypeGuid, string expectedFileExtension, string expectedProjectTypeGuid)

--- a/src/SlnGen.Build.Tasks/Internal/SlnFile.cs
+++ b/src/SlnGen.Build.Tasks/Internal/SlnFile.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -32,6 +33,11 @@ namespace SlnGen.Build.Tasks.Internal
         private readonly IReadOnlyList<SlnProject> _projects;
 
         /// <summary>
+        /// A list of absolute paths to include as Solution Items.
+        /// </summary>
+        private readonly List<string> _solutionItems = new List<string>();
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="SlnFile" /> class.
         /// </summary>
         /// <param name="projects">The project collection.</param>
@@ -56,6 +62,19 @@ namespace SlnGen.Build.Tasks.Internal
         }
 
         /// <summary>
+        /// Gets a list of solution items.
+        /// </summary>
+        public IReadOnlyCollection<string> SolutionItems => _solutionItems;
+
+        /// <summary>
+        /// Adds the specified solution items.
+        /// </summary>
+        public void AddSolutionItems(IEnumerable<string> items)
+        {
+            _solutionItems.AddRange(items);
+        }
+
+        /// <summary>
         /// Saves the Visual Studio solution to a file.
         /// </summary>
         /// <param name="path">The full path to the file to write to.</param>
@@ -74,6 +93,18 @@ namespace SlnGen.Build.Tasks.Internal
             foreach (SlnProject project in _projects)
             {
                 writer.WriteLine($@"Project(""{project.ProjectTypeGuid}"") = ""{project.Name}"", ""{project.FullPath}"", ""{project.ProjectGuid}""");
+                writer.WriteLine("EndProject");
+            }
+
+            if (SolutionItems.Count > 0)
+            {
+                writer.WriteLine($@"Project(""{SlnFolder.ProjectTypeGuid}"") = ""Solution Items"", ""Solution Items"", ""{Guid.NewGuid().ToSolutionString()}"" ");
+                writer.WriteLine("	ProjectSection(SolutionItems) = preProject");
+                foreach (string solutionItem in SolutionItems)
+                {
+                    writer.WriteLine($"		{solutionItem} = {solutionItem}");
+                }
+                writer.WriteLine("	EndProjectSection");
                 writer.WriteLine("EndProject");
             }
 

--- a/src/SlnGen.Build.Tasks/Internal/SlnFolder.cs
+++ b/src/SlnGen.Build.Tasks/Internal/SlnFolder.cs
@@ -4,6 +4,8 @@ namespace SlnGen.Build.Tasks.Internal
 {
     internal sealed class SlnFolder
     {
+        public const string ProjectTypeGuid = "{2150E333-8FDC-42A3-9474-1A3956D46DE8}";
+
         public SlnFolder(string path, string guid)
         {
             Name = Path.GetFileName(path);
@@ -17,6 +19,6 @@ namespace SlnGen.Build.Tasks.Internal
 
         public string Name { get; }
 
-        public string TypeGuid => "{2150E333-8FDC-42A3-9474-1A3956D46DE8}";
+        public string TypeGuid => ProjectTypeGuid;
     }
 }

--- a/src/SlnGen.Build.Tasks/SlnGen.targets
+++ b/src/SlnGen.Build.Tasks/SlnGen.targets
@@ -31,6 +31,7 @@
       ProjectReferences="@(_MSBuildProjectReferenceExistent)"
       ShouldLaunchVisualStudio="$([MSBuild]::ValueOrDefault('$(SlnGenLaunchVisualStudio)', 'true'))"
       SolutionFileFullPath="$(SlnGenSolutionFileFullPath)"
+      SolutionItems="@(SlnGenSolutionItem)"
       ToolsVersion="$([MSBuild]::ValueOrDefault('$(SlnGenToolsVersion)', '$(MSBuildToolsVersion)'))"
       UseShellExecute="$([MSBuild]::ValueOrDefault('$(SlnGenUseShellExecute)', 'true'))"
       />


### PR DESCRIPTION
Whatever is in the `@(SlGenSolutionItem)` for the main project will be added to the solution.

Example:
```xml
<ItemGroup>
  <SlnGenSolutionItem Include="$(MSBuildThisFileDirectory)\Directory.Build.props" />
</ItemGroup>
```