### PR TITLE
Add new project type GUIDs for .NET SDK projects

### DIFF
--- a/src/SlnGen.Build.Tasks.UnitTests/SlnFileTests.cs
+++ b/src/SlnGen.Build.Tasks.UnitTests/SlnFileTests.cs
@@ -33,7 +33,7 @@ namespace SlnGen.Build.Tasks.UnitTests
                 // pick random and shuffled configurations and platforms
                 var projectConfigurations = configurations.OrderBy(a => Guid.NewGuid()).Take(randomGenerator.Next(1, configurations.Length)).ToList();
                 var projectPlatforms = platforms.OrderBy(a => Guid.NewGuid()).Take(randomGenerator.Next(1, platforms.Length)).ToList();
-                projects[i] = new SlnProject(GetTempFileName(), $"Project{i:D6}", Guid.NewGuid(), Guid.NewGuid().ToSolutionString(), projectConfigurations, projectPlatforms, isMainProject: i == 0);
+                projects[i] = new SlnProject(GetTempFileName(), $"Project{i:D6}", Guid.NewGuid(), Guid.NewGuid(), projectConfigurations, projectPlatforms, isMainProject: i == 0);
             }
 
             ValidateProjectInSolution(projects);
@@ -42,8 +42,8 @@ namespace SlnGen.Build.Tasks.UnitTests
         [Fact]
         public void MultipleProjects()
         {
-            SlnProject projectA = new SlnProject(GetTempFileName(), "ProjectA", Guid.Parse("C95D800E-F016-4167-8E1B-1D3FF94CE2E2"), "88152E7E-47E3-45C8-B5D3-DDB15B2F0435", new[] { "Debug" }, new[] { "x64" }, isMainProject: true);
-            SlnProject projectB = new SlnProject(GetTempFileName(), "ProjectB", Guid.Parse("EAD108BE-AC70-41E6-A8C3-450C545FDC0E"), "F38341C3-343F-421A-AE68-94CD9ADCD32F", new[] { "Debug" }, new[] { "x64" }, isMainProject: false);
+            SlnProject projectA = new SlnProject(GetTempFileName(), "ProjectA", new Guid("C95D800E-F016-4167-8E1B-1D3FF94CE2E2"), new Guid("88152E7E-47E3-45C8-B5D3-DDB15B2F0435"), new[] { "Debug" }, new[] { "x64" }, isMainProject: true);
+            SlnProject projectB = new SlnProject(GetTempFileName(), "ProjectB", new Guid("EAD108BE-AC70-41E6-A8C3-450C545FDC0E"), new Guid("F38341C3-343F-421A-AE68-94CD9ADCD32F"), new[] { "Debug" }, new[] { "x64" }, isMainProject: false);
 
             ValidateProjectInSolution(projectA, projectB);
         }
@@ -51,7 +51,7 @@ namespace SlnGen.Build.Tasks.UnitTests
         [Fact]
         public void SingleProject()
         {
-            SlnProject projectA = new SlnProject(GetTempFileName(), "ProjectA", Guid.Parse("C95D800E-F016-4167-8E1B-1D3FF94CE2E2"), "88152E7E-47E3-45C8-B5D3-DDB15B2F0435", new[] { "Debug" }, new[] { "x64" }, isMainProject: true);
+            SlnProject projectA = new SlnProject(GetTempFileName(), "ProjectA", new Guid("C95D800E-F016-4167-8E1B-1D3FF94CE2E2"), new Guid("88152E7E-47E3-45C8-B5D3-DDB15B2F0435"), new[] { "Debug" }, new[] { "x64" }, isMainProject: true);
 
             ValidateProjectInSolution(projectA);
         }

--- a/src/SlnGen.Build.Tasks.UnitTests/SlnGenTests.cs
+++ b/src/SlnGen.Build.Tasks.UnitTests/SlnGenTests.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Build.Framework;
 using Shouldly;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,7 +17,7 @@ namespace SlnGen.Build.Tasks.UnitTests
         [Fact]
         public void ParseCustomProjectTypeGuidsDeduplicatesList()
         {
-            const string expectedProjectTypeGuid = "{C139C737-2894-46A0-B1EB-DDD052FD8DCB}";
+            Guid expectedProjectTypeGuid = new Guid("C139C737-2894-46A0-B1EB-DDD052FD8DCB");
 
             ITaskItem[] customProjectTypeGuids =
             {
@@ -26,7 +27,7 @@ namespace SlnGen.Build.Tasks.UnitTests
                 },
                 new MockTaskItem(".foo")
                 {
-                    { SlnGen.CustomProjectTypeGuidMetadataName, expectedProjectTypeGuid }
+                    { SlnGen.CustomProjectTypeGuidMetadataName, expectedProjectTypeGuid.ToString() }
                 },
             };
 
@@ -40,13 +41,13 @@ namespace SlnGen.Build.Tasks.UnitTests
                 " .FoO  ",
                 "  9d9339782d2a4fb2b72d8746d88e73b7 ",
                 ".foo",
-                "{9D933978-2D2A-4FB2-B72D-8746D88E73B7}");
+                new Guid("9D933978-2D2A-4FB2-B72D-8746D88E73B7"));
         }
 
         [Fact]
         public void ParseCustomProjectTypeGuidsIgnoresNonFileExtensions()
         {
-            const string expectedProjectTypeGuid = "{C139C737-2894-46A0-B1EB-DDD052FD8DCB}";
+            Guid expectedProjectTypeGuid = new Guid("C139C737-2894-46A0-B1EB-DDD052FD8DCB");
 
             ITaskItem[] customProjectTypeGuids =
             {
@@ -56,7 +57,7 @@ namespace SlnGen.Build.Tasks.UnitTests
                 },
                 new MockTaskItem(".foo")
                 {
-                    { SlnGen.CustomProjectTypeGuidMetadataName, expectedProjectTypeGuid }
+                    { SlnGen.CustomProjectTypeGuidMetadataName, expectedProjectTypeGuid.ToString() }
                 },
             };
 
@@ -86,7 +87,7 @@ namespace SlnGen.Build.Tasks.UnitTests
             slnGen.GetSolutionItems(path => true).ShouldBe(solutionItems.Values);
         }
 
-        private static void ValidateParseCustomProjectTypeGuids(string fileExtension, string projectTypeGuid, string expectedFileExtension, string expectedProjectTypeGuid)
+        private static void ValidateParseCustomProjectTypeGuids(string fileExtension, string projectTypeGuid, string expectedFileExtension, Guid expectedProjectTypeGuid)
         {
             ITaskItem[] customProjectTypeGuids =
             {
@@ -99,16 +100,16 @@ namespace SlnGen.Build.Tasks.UnitTests
             ValidateParseCustomProjectTypeGuids(customProjectTypeGuids, expectedFileExtension, expectedProjectTypeGuid);
         }
 
-        private static void ValidateParseCustomProjectTypeGuids(ITaskItem[] customProjectTypeGuids, string expectedFileExtension, string expectedProjectTypeGuid)
+        private static void ValidateParseCustomProjectTypeGuids(ITaskItem[] customProjectTypeGuids, string expectedFileExtension, Guid expectedProjectTypeGuid)
         {
             SlnGen slnGen = new SlnGen
             {
                 CustomProjectTypeGuids = customProjectTypeGuids
             };
 
-            Dictionary<string, string> actualProjectTypeGuids = slnGen.ParseCustomProjectTypeGuids();
+            Dictionary<string, Guid> actualProjectTypeGuids = slnGen.ParseCustomProjectTypeGuids();
 
-            KeyValuePair<string, string> actualProjectTypeGuid = actualProjectTypeGuids.ShouldHaveSingleItem();
+            KeyValuePair<string, Guid> actualProjectTypeGuid = actualProjectTypeGuids.ShouldHaveSingleItem();
 
             actualProjectTypeGuid.Key.ShouldBe(expectedFileExtension);
             actualProjectTypeGuid.Value.ShouldBe(expectedProjectTypeGuid);

--- a/src/SlnGen.Build.Tasks/Internal/SlnFile.cs
+++ b/src/SlnGen.Build.Tasks/Internal/SlnFile.cs
@@ -83,13 +83,13 @@ namespace SlnGen.Build.Tasks.Internal
 
             foreach (SlnProject project in _projects)
             {
-                writer.WriteLine($@"Project(""{project.ProjectTypeGuid}"") = ""{project.Name}"", ""{project.FullPath}"", ""{project.ProjectGuid.ToSolutionString()}""");
+                writer.WriteLine($@"Project(""{project.ProjectTypeGuid.ToSolutionString()}"") = ""{project.Name}"", ""{project.FullPath}"", ""{project.ProjectGuid.ToSolutionString()}""");
                 writer.WriteLine("EndProject");
             }
 
             if (SolutionItems.Count > 0)
             {
-                writer.WriteLine($@"Project(""{SlnFolder.ProjectTypeGuid}"") = ""Solution Items"", ""Solution Items"", ""{Guid.NewGuid().ToSolutionString()}"" ");
+                writer.WriteLine($@"Project(""{SlnFolder.FolderProjectTypeGuid.ToSolutionString()}"") = ""Solution Items"", ""Solution Items"", ""{Guid.NewGuid().ToSolutionString()}"" ");
                 writer.WriteLine("	ProjectSection(SolutionItems) = preProject");
                 foreach (string solutionItem in SolutionItems)
                 {
@@ -106,7 +106,7 @@ namespace SlnGen.Build.Tasks.Internal
             {
                 foreach (SlnFolder folder in hierarchy.Folders)
                 {
-                    writer.WriteLine($@"Project(""{folder.TypeGuid}"") = ""{folder.Name}"", ""{folder.FullPath}"", ""{folder.Guid}""");
+                    writer.WriteLine($@"Project(""{folder.ProjectTypeGuid.ToSolutionString()}"") = ""{folder.Name}"", ""{folder.FullPath}"", ""{folder.FolderGuid.ToSolutionString()}""");
                     writer.WriteLine("EndProject");
                 }
             }
@@ -152,9 +152,9 @@ namespace SlnGen.Build.Tasks.Internal
             if (_projects.Count > 1)
             {
                 writer.WriteLine(@"	GlobalSection(NestedProjects) = preSolution");
-                foreach (KeyValuePair<string, string> nestedProject in hierarchy.Hierarchy)
+                foreach (KeyValuePair<Guid, Guid> nestedProject in hierarchy.Hierarchy)
                 {
-                    writer.WriteLine($@"		{nestedProject.Key} = {nestedProject.Value}");
+                    writer.WriteLine($@"		{nestedProject.Key.ToSolutionString()} = {nestedProject.Value.ToSolutionString()}");
                 }
 
                 writer.WriteLine("	EndGlobalSection");

--- a/src/SlnGen.Build.Tasks/Internal/SlnFolder.cs
+++ b/src/SlnGen.Build.Tasks/Internal/SlnFolder.cs
@@ -2,27 +2,28 @@
 //
 // Licensed under the MIT license.
 
+using System;
 using System.IO;
 
 namespace SlnGen.Build.Tasks.Internal
 {
     internal sealed class SlnFolder
     {
-        public const string ProjectTypeGuid = "{2150E333-8FDC-42A3-9474-1A3956D46DE8}";
+        public static readonly Guid FolderProjectTypeGuid = new Guid("{2150E333-8FDC-42A3-9474-1A3956D46DE8}");
 
-        public SlnFolder(string path, string guid)
+        public SlnFolder(string path, Guid folderGuid)
         {
             Name = Path.GetFileName(path);
             FullPath = path;
-            Guid = guid;
+            FolderGuid = folderGuid;
         }
 
         public string FullPath { get; }
 
-        public string Guid { get; }
+        public Guid FolderGuid { get; }
 
         public string Name { get; }
 
-        public string TypeGuid => ProjectTypeGuid;
+        public Guid ProjectTypeGuid => FolderProjectTypeGuid;
     }
 }

--- a/src/SlnGen.Build.Tasks/Internal/SlnHierarchy.cs
+++ b/src/SlnGen.Build.Tasks/Internal/SlnHierarchy.cs
@@ -16,8 +16,8 @@ namespace SlnGen.Build.Tasks.Internal
     internal sealed class SlnHierarchy
     {
         private readonly List<SlnFolder> _folders = new List<SlnFolder>();
-        private readonly Dictionary<string, string> _hierarchy = new Dictionary<string, string>();
-        private readonly Dictionary<string, string> _itemId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<Guid, Guid> _hierarchy = new Dictionary<Guid, Guid>();
+        private readonly Dictionary<string, Guid> _itemId = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase);
 
         private SlnHierarchy()
         {
@@ -25,7 +25,7 @@ namespace SlnGen.Build.Tasks.Internal
 
         public IReadOnlyCollection<SlnFolder> Folders => _folders;
 
-        public IReadOnlyDictionary<string, string> Hierarchy => _hierarchy;
+        public IReadOnlyDictionary<Guid, Guid> Hierarchy => _hierarchy;
 
         public static SlnHierarchy FromProjects(IReadOnlyList<SlnProject> projects)
         {
@@ -84,14 +84,14 @@ namespace SlnGen.Build.Tasks.Internal
         {
             // TODO: Collapse folders with single sub folder.  So if foo had just a subfolder bar, collapse it to foo\bar in Visual Studio
             string parent = Directory.GetParent(project.FullPath).FullName;
-            string currentGuid = project.ProjectGuid.ToSolutionString();
+            Guid currentGuid = project.ProjectGuid;
 
             while (true)
             {
-                bool visited = _itemId.TryGetValue(parent, out string parentGuid);
+                bool visited = _itemId.TryGetValue(parent, out Guid parentGuid);
                 if (!visited)
                 {
-                    parentGuid = Guid.NewGuid().ToSolutionString();
+                    parentGuid = Guid.NewGuid();
                     _itemId.Add(parent, parentGuid);
                     _folders.Add(new SlnFolder(parent, parentGuid));
                 }

--- a/src/SlnGen.Build.Tasks/Internal/SlnProject.cs
+++ b/src/SlnGen.Build.Tasks/Internal/SlnProject.cs
@@ -15,32 +15,56 @@ namespace SlnGen.Build.Tasks.Internal
         public const string AssemblyNamePropertyName = "AssemblyName";
         public const string ProjectGuidPropertyName = "ProjectGuid";
         public const string UsingMicrosoftNetSdkPropertyName = "UsingMicrosoftNETSdk";
-        public const string DefaultProjectTypeGuid = "FAE04EC0-301F-11D3-BF4B-00C04F79EFBC";
+        public static readonly Guid DefaultLegacyProjectTypeGuid = new Guid("FAE04EC0-301F-11D3-BF4B-00C04F79EFBC");
+        public static readonly Guid DefaultNetSdkProjectTypeGuid = new Guid("9A19103F-16F7-4668-BE54-9A1E7A4F7556");
 
-        public static readonly IReadOnlyDictionary<string, string> KnownProjectTypeGuids = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        /// <summary>
+        /// Known project type GUIDs for legacy projects.
+        /// </summary>
+        public static readonly IReadOnlyDictionary<string, Guid> KnownLegacyProjectTypeGuids = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase)
         {
-            { ".ccproj", "151D2E53-A2C4-4D7D-83FE-D05416EBD58E" },
-            { ".csproj", DefaultProjectTypeGuid },
-            { ".fsproj", "F2A71F9B-5D33-465A-A702-920D77279786" },
-            { ".nativeProj", "8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942" },
-            { ".nuproj", "FF286327-C783-4F7A-AB73-9BCBAD0D4460" },
-            { ".vbproj", "F184B08F-C81C-45F6-A57F-5ABD9991F28F" },
-            { ".vcproj", "8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942" },
-            { ".vcxproj", "8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942" },
-            { ".vjsproj", "E6FDF86B-F3D1-11D4-8576-0002A516ECE8" },
-            { ".wixproj", "930C7802-8A8C-48F9-8165-68863BCCD9DD" },
+            [string.Empty] = DefaultLegacyProjectTypeGuid,
+            [".csproj"] = DefaultLegacyProjectTypeGuid,
+            [".vbproj"] = new Guid("F184B08F-C81C-45F6-A57F-5ABD9991F28F"),
         };
 
-        public SlnProject([NotNull] string fullPath, [NotNull] string name, Guid projectGuid, [NotNull] string projectTypeGuid, [NotNull] IEnumerable<string> configurations, [NotNull] IEnumerable<string> platforms, bool isMainProject)
+        /// <summary>
+        /// Known project type GUIDs for .NET SDK projects.
+        /// </summary>
+        public static readonly IReadOnlyDictionary<string, Guid> KnownNetSdkProjectTypeGuids = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase)
+        {
+            [string.Empty] = DefaultNetSdkProjectTypeGuid,
+            [".csproj"] = DefaultNetSdkProjectTypeGuid,
+            [".vbproj"] = new Guid("778DAE3C-4631-46EA-AA77-85C1314464D9"),
+        };
+
+        /// <summary>
+        /// Known project type GUIDs for all project types.
+        /// </summary>
+        public static readonly IReadOnlyDictionary<string, Guid> KnownProjectTypeGuids = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase)
+        {
+            [".ccproj"] = new Guid("151D2E53-A2C4-4D7D-83FE-D05416EBD58E"),
+            [".fsproj"] = new Guid("F2A71F9B-5D33-465A-A702-920D77279786"),
+            [".nativeProj"] = new Guid("8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942"),
+            [".nuproj"] = new Guid("FF286327-C783-4F7A-AB73-9BCBAD0D4460"),
+            [".vcproj"] = new Guid("8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942"),
+            [".vcxproj"] = new Guid("8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942"),
+            [".vjsproj"] = new Guid("E6FDF86B-F3D1-11D4-8576-0002A516ECE8"),
+            [".wixproj"] = new Guid("930C7802-8A8C-48F9-8165-68863BCCD9DD")
+        };
+
+        public SlnProject([NotNull] string fullPath, [NotNull] string name, Guid projectGuid, Guid projectTypeGuid, [NotNull] IEnumerable<string> configurations, [NotNull] IEnumerable<string> platforms, bool isMainProject)
         {
             FullPath = fullPath ?? throw new ArgumentNullException(nameof(fullPath));
             Name = name ?? throw new ArgumentNullException(nameof(name));
             ProjectGuid = projectGuid;
-            ProjectTypeGuid = projectTypeGuid ?? throw new ArgumentNullException(nameof(projectTypeGuid));
+            ProjectTypeGuid = projectTypeGuid;
             IsMainProject = isMainProject;
             Configurations = configurations;
             Platforms = platforms;
         }
+
+        public IEnumerable<string> Configurations { get; }
 
         public string FullPath { get; }
 
@@ -48,16 +72,14 @@ namespace SlnGen.Build.Tasks.Internal
 
         public string Name { get; }
 
-        public Guid ProjectGuid { get; }
-
-        public string ProjectTypeGuid { get; }
-
-        public IEnumerable<string> Configurations { get; }
-
         public IEnumerable<string> Platforms { get; }
 
+        public Guid ProjectGuid { get; }
+
+        public Guid ProjectTypeGuid { get; }
+
         [NotNull]
-        public static SlnProject FromProject([NotNull] Project project, [NotNull] IReadOnlyDictionary<string, string> customProjectTypeGuids, bool isMainProject = false)
+        public static SlnProject FromProject([NotNull] Project project, [NotNull] IReadOnlyDictionary<string, Guid> customProjectTypeGuids, bool isMainProject = false)
         {
             if (project == null)
             {
@@ -71,29 +93,52 @@ namespace SlnGen.Build.Tasks.Internal
 
             string name = project.GetPropertyValueOrDefault(AssemblyNamePropertyName, Path.GetFileNameWithoutExtension(project.FullPath));
 
-            // Legacy projects do not set UsingMicrosoftNETSdk to "true"
-            bool isLegacyProjectSystem = !project.GetPropertyValue(UsingMicrosoftNetSdkPropertyName).Equals("true", StringComparison.OrdinalIgnoreCase);
+            bool isUsingMicrosoftNetSdk = project.GetPropertyValue(UsingMicrosoftNetSdkPropertyName).Equals("true", StringComparison.OrdinalIgnoreCase);
 
             string extension = Path.GetExtension(project.FullPath);
 
-            // Get the item from the custom project type GUIDs first which can override ours
-            if (String.IsNullOrWhiteSpace(extension) || (!customProjectTypeGuids.TryGetValue(extension, out string projectTypeGuid) && !KnownProjectTypeGuids.TryGetValue(extension, out projectTypeGuid)))
-            {
-                projectTypeGuid = DefaultProjectTypeGuid;
-            }
+            Guid projectTypeGuid = GetKnownProjectTypeGuid(extension, isUsingMicrosoftNetSdk, customProjectTypeGuids);
 
             IEnumerable<string> configurations = project.GetPossiblePropertyValuesOrDefault("Configuration", "Debug");
             IEnumerable<string> platforms = project.GetPossiblePropertyValuesOrDefault("Platform", "AnyCPU");
 
-            if (!Guid.TryParse(
-                isLegacyProjectSystem
-                    ? project.GetPropertyValueOrDefault(ProjectGuidPropertyName, Guid.NewGuid().ToString())
-                    : Guid.NewGuid().ToString(), out Guid projectGuid))
+            Guid projectGuid = Guid.NewGuid();
+
+            if (!isUsingMicrosoftNetSdk && !Guid.TryParse(project.GetPropertyValueOrDefault(ProjectGuidPropertyName, projectGuid.ToString()), out projectGuid))
             {
                 throw new FormatException($"property ProjectGuid has an invalid format in {project.FullPath}");
             }
 
             return new SlnProject(project.FullPath, name, projectGuid, projectTypeGuid, configurations, platforms, isMainProject);
+        }
+
+        /// <summary>
+        /// Determines the project type GUID for the specified file extension.
+        /// </summary>
+        /// <param name="extension">The file extension of the project.</param>
+        /// <param name="isUsingMicrosoftNetSdk">Indicates whether or not the project is using the Microsoft.NET.Sdk.</param>
+        /// <param name="customProjectTypeGuids">A list of custom project type GUIDs to use.</param>
+        /// <returns>The project type GUID for the specfied project extension.</returns>
+        internal static Guid GetKnownProjectTypeGuid(string extension, bool isUsingMicrosoftNetSdk, IReadOnlyDictionary<string, Guid> customProjectTypeGuids)
+        {
+            if (customProjectTypeGuids.TryGetValue(extension, out Guid projectTypeGuid) || KnownProjectTypeGuids.TryGetValue(extension, out projectTypeGuid))
+            {
+                return projectTypeGuid;
+            }
+
+            // Use GUIDs for .NET SDK projects
+            if (isUsingMicrosoftNetSdk && !KnownNetSdkProjectTypeGuids.TryGetValue(extension, out projectTypeGuid))
+            {
+                projectTypeGuid = DefaultNetSdkProjectTypeGuid;
+            }
+
+            // Use GUIDs for legacy projects
+            if (!isUsingMicrosoftNetSdk && !KnownLegacyProjectTypeGuids.TryGetValue(extension, out projectTypeGuid))
+            {
+                projectTypeGuid = DefaultLegacyProjectTypeGuid;
+            }
+
+            return projectTypeGuid;
         }
     }
 }

--- a/src/SlnGen.Build.Tasks/SlnGen.cs
+++ b/src/SlnGen.Build.Tasks/SlnGen.cs
@@ -134,9 +134,9 @@ namespace SlnGen.Build.Tasks
         }
 
         [NotNull]
-        internal Dictionary<string, string> ParseCustomProjectTypeGuids()
+        internal Dictionary<string, Guid> ParseCustomProjectTypeGuids()
         {
-            Dictionary<string, string> projectTypeGuids = new Dictionary<string, string>();
+            Dictionary<string, Guid> projectTypeGuids = new Dictionary<string, Guid>();
 
             foreach (ITaskItem taskItem in CustomProjectTypeGuids)
             {
@@ -153,7 +153,7 @@ namespace SlnGen.Build.Tasks
                 if (!String.IsNullOrWhiteSpace(projectTypeGuidString) && Guid.TryParse(projectTypeGuidString, out Guid projectTypeGuid))
                 {
                     // Trim and ToLower the file extension
-                    projectTypeGuids[taskItem.ItemSpec.Trim().ToLowerInvariant()] = projectTypeGuid.ToSolutionString();
+                    projectTypeGuids[taskItem.ItemSpec.Trim().ToLowerInvariant()] = projectTypeGuid;
                 }
             }
 
@@ -200,14 +200,14 @@ namespace SlnGen.Build.Tasks
                 SolutionFileFullPath = Path.ChangeExtension(ProjectFullPath, ".sln");
             }
 
-            Dictionary<string, string> customProjectTypeGuids = ParseCustomProjectTypeGuids();
+            Dictionary<string, Guid> customProjectTypeGuids = ParseCustomProjectTypeGuids();
 
             LogMessageHigh($"Generating Visual Studio solution \"{SolutionFileFullPath}\" ...");
 
             if (customProjectTypeGuids.Count > 0)
             {
                 LogMessageLow("Custom Project Type GUIDs:");
-                foreach (KeyValuePair<string, string> item in customProjectTypeGuids)
+                foreach (KeyValuePair<string, Guid> item in customProjectTypeGuids)
                 {
                     LogMessageLow("  {0} = {1}", item.Key, item.Value);
                 }


### PR DESCRIPTION
Use a `Guid` instead of a `string` for storing the values.

Have a dictionary for legacy/NET SDK project type GUIDS

Added some unit tests

Fixes #29