### PR TITLE
Added option to specify custom target folder for solution items

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ SlnGen is an MSBuild target so you will need to add a `<PackageReference />` to 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="SlnGen">
-      <Version>2.0.0</Version>
+      <Version>2.1.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>
@@ -113,6 +113,26 @@ To add to this list or override an item, specify an `SlnGenCustomProjectTypeGuid
     <ProjectTypeGuid>{bb9d1d44-b292-4016-9ce0-27ea600e8e1c}</ProjectTypeGuid>
   </SlnGenCustomProjectTypeGuid>
 
+</ItemGroup>
+```
+
+## Solution Items
+
+To add solution items to the solution, specify them using the `SlnGenSolutionItem` item.
+
+| Item                        | Description                              |
+|-----------------------------|------------------------------------------|
+| SlnGenSolutionItem          | Specifies a file to add to the solution. |
+
+| Metadata    | Description                                                                       |
+|-------------|-----------------------------------------------------------------------------------|
+| Folder      | Specifies the target folder for the solution item, relative to the solution root. |
+
+```xml
+<ItemGroup>
+  <SlnGenSolutionItem Include="build\Key.snk">
+    <Folder>build</Folder>
+  </SlnGenSolutionItem>
 </ItemGroup>
 ```
 

--- a/src/SlnGen.Build.Tasks.UnitTests/MockTaskItem.cs
+++ b/src/SlnGen.Build.Tasks.UnitTests/MockTaskItem.cs
@@ -43,7 +43,12 @@ namespace SlnGen.Build.Tasks.UnitTests
 
         public string GetMetadata(string metadataName)
         {
-            return this[metadataName];
+            if (TryGetValue(metadataName, out var value))
+            {
+                return value;
+            }
+
+            return String.Empty;
         }
 
         public void RemoveMetadata(string metadataName)

--- a/src/SlnGen.Build.Tasks.UnitTests/SlnGenTests.cs
+++ b/src/SlnGen.Build.Tasks.UnitTests/SlnGenTests.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Build.Framework;
 using Shouldly;
+using SlnGen.Build.Tasks.Internal;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -67,10 +68,10 @@ namespace SlnGen.Build.Tasks.UnitTests
         [Fact]
         public void SolutionItems()
         {
-            Dictionary<string, string> solutionItems = new Dictionary<string, string>
+            Dictionary<string, SlnItem> solutionItems = new Dictionary<string, SlnItem>
             {
-                { "foo", Path.GetFullPath("foo") },
-                { "bar", Path.GetFullPath("bar") }
+                { "foo", new SlnItem(Path.GetFullPath("foo"), String.Empty) },
+                { "bar", new SlnItem(Path.GetFullPath("bar"), "build") }
             };
 
             IBuildEngine buildEngine = new MockBuildEngine();
@@ -80,11 +81,12 @@ namespace SlnGen.Build.Tasks.UnitTests
                 BuildEngine = buildEngine,
                 SolutionItems = solutionItems.Select(i => new MockTaskItem(i.Key)
                 {
-                    { "FullPath", i.Value }
+                    { "FullPath", i.Value.FullPath },
+                    { "TargetFolder", i.Value.TargetFolder }
                 }).ToArray<ITaskItem>()
             };
 
-            slnGen.GetSolutionItems(path => true).ShouldBe(solutionItems.Values);
+            slnGen.GetSolutionItems(path => true).Select(i => i.TargetFolder).ShouldAllBe(f => !String.IsNullOrEmpty(f));
         }
 
         private static void ValidateParseCustomProjectTypeGuids(string fileExtension, string projectTypeGuid, string expectedFileExtension, Guid expectedProjectTypeGuid)

--- a/src/SlnGen.Build.Tasks.UnitTests/SlnProjectTests.cs
+++ b/src/SlnGen.Build.Tasks.UnitTests/SlnProjectTests.cs
@@ -170,7 +170,7 @@ namespace SlnGen.Build.Tasks.UnitTests
         [Fact]
         public void UseAssemblyNameProperty()
         {
-            CreateAndValidateProject(expectedGuid: "{3EA7B89C-F85F-49F4-B99D-1BC184C08186}", expectedName: "Project.Name");
+            CreateAndValidateProject(expectedGuid: "{3EA7B89C-F85F-49F4-B99D-1BC184C08186}");
         }
 
         [Fact]
@@ -179,18 +179,15 @@ namespace SlnGen.Build.Tasks.UnitTests
             CreateAndValidateProject(expectedGuid: "{DE681393-7151-459D-862C-918CCD2CB371}");
         }
 
-        private SlnProject CreateAndValidateProject(bool isMainProject = false, string expectedGuid = null, string expectedName = null, string extension = ".csproj", IDictionary<string, string> globalProperties = null)
+        private SlnProject CreateAndValidateProject(bool isMainProject = false, string expectedGuid = null, string extension = ".csproj", IDictionary<string, string> globalProperties = null)
         {
-            Project expectedProject = CreateProject(expectedGuid, expectedName, extension, globalProperties);
+            Project expectedProject = CreateProject(expectedGuid, extension, globalProperties);
 
             SlnProject actualProject = SlnProject.FromProject(expectedProject, new Dictionary<string, Guid>(), isMainProject);
 
             actualProject.FullPath.ShouldBe(expectedProject.FullPath);
 
-            if (!string.IsNullOrWhiteSpace(expectedName))
-            {
-                actualProject.Name.ShouldBe(expectedName);
-            }
+            actualProject.Name.ShouldBe(expectedProject.GetPropertyValue(SlnProject.MSBuildProjectNamePropertyName));
 
             if (expectedGuid != null)
             {
@@ -202,7 +199,7 @@ namespace SlnGen.Build.Tasks.UnitTests
             return actualProject;
         }
 
-        private Project CreateProject(string projectGuid = null, string name = null, string extension = ".csproj", IDictionary<string, string> globalProperties = null)
+        private Project CreateProject(string projectGuid = null, string extension = ".csproj", IDictionary<string, string> globalProperties = null)
         {
             string fullPath = GetTempFileName(extension);
 
@@ -214,11 +211,6 @@ namespace SlnGen.Build.Tasks.UnitTests
             if (!string.IsNullOrWhiteSpace(projectGuid))
             {
                 globalProperties[SlnProject.ProjectGuidPropertyName] = projectGuid;
-            }
-
-            if (!string.IsNullOrWhiteSpace(name))
-            {
-                globalProperties[SlnProject.AssemblyNamePropertyName] = name;
             }
 
             return MockProject.Create(fullPath, globalProperties);

--- a/src/SlnGen.Build.Tasks/Internal/SlnItem.cs
+++ b/src/SlnGen.Build.Tasks/Internal/SlnItem.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Jeff Kluge. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using System;
+
+namespace SlnGen.Build.Tasks.Internal
+{
+    internal sealed class SlnItem
+    {
+        public SlnItem(string path, string targetFolder)
+        {
+            if (String.IsNullOrWhiteSpace(targetFolder))
+            {
+                targetFolder = "Solution Items";
+            }
+
+            FullPath = path;
+            TargetFolder = targetFolder;
+        }
+
+        public string FullPath { get; }
+
+        public string TargetFolder { get; }
+    }
+}

--- a/src/SlnGen.Build.Tasks/Internal/SlnProject.cs
+++ b/src/SlnGen.Build.Tasks/Internal/SlnProject.cs
@@ -12,7 +12,7 @@ namespace SlnGen.Build.Tasks.Internal
 {
     internal sealed class SlnProject
     {
-        public const string AssemblyNamePropertyName = "AssemblyName";
+        public const string MSBuildProjectNamePropertyName = "MSBuildProjectName";
         public const string ProjectGuidPropertyName = "ProjectGuid";
         public const string UsingMicrosoftNetSdkPropertyName = "UsingMicrosoftNETSdk";
         public static readonly Guid DefaultLegacyProjectTypeGuid = new Guid("FAE04EC0-301F-11D3-BF4B-00C04F79EFBC");
@@ -91,7 +91,7 @@ namespace SlnGen.Build.Tasks.Internal
                 throw new ArgumentNullException(nameof(customProjectTypeGuids));
             }
 
-            string name = project.GetPropertyValueOrDefault(AssemblyNamePropertyName, Path.GetFileNameWithoutExtension(project.FullPath));
+            string name = project.GetPropertyValueOrDefault(MSBuildProjectNamePropertyName, Path.GetFileNameWithoutExtension(project.FullPath));
 
             bool isUsingMicrosoftNetSdk = project.GetPropertyValue(UsingMicrosoftNetSdkPropertyName).Equals("true", StringComparison.OrdinalIgnoreCase);
 

--- a/src/SlnGen.Build.Tasks/SlnGen.cs
+++ b/src/SlnGen.Build.Tasks/SlnGen.cs
@@ -113,7 +113,7 @@ namespace SlnGen.Build.Tasks
         /// Gets the solution items' full paths.
         /// </summary>
         /// <returns>An <see cref="IEnumerable{String}"/> of full paths to include as solution items.</returns>
-        internal IEnumerable<string> GetSolutionItems()
+        internal IEnumerable<SlnItem> GetSolutionItems()
         {
             return GetSolutionItems(File.Exists);
         }
@@ -123,17 +123,24 @@ namespace SlnGen.Build.Tasks
         /// </summary>
         /// <param name="fileExists">A <see cref="Func{String, Boolean}"/> to use when determining if a file exists.</param>
         /// <returns>An <see cref="IEnumerable{String}"/> of full paths to include as solution items.</returns>
-        internal IEnumerable<string> GetSolutionItems(Func<string, bool> fileExists)
+        internal IEnumerable<SlnItem> GetSolutionItems(Func<string, bool> fileExists)
         {
-            foreach (string solutionItem in SolutionItems.Select(i => i.GetMetadata("FullPath")).Where(i => !String.IsNullOrWhiteSpace(i)))
+            foreach (var solutionItem in SolutionItems)
             {
-                if (!fileExists(solutionItem))
+                var fullPath = solutionItem.GetMetadata("FullPath");
+
+                if (String.IsNullOrWhiteSpace(fullPath))
                 {
-                    LogMessageLow($"The solution item \"{solutionItem}\" does not exist and will not be added to the solution.");
+                    continue;
+                }
+
+                if (!fileExists(fullPath))
+                {
+                    LogMessageLow($"The solution item \"{fullPath}\" does not exist and will not be added to the solution.");
                 }
                 else
                 {
-                    yield return solutionItem;
+                    yield return new SlnItem(fullPath, solutionItem.GetMetadata("Folder"));
                 }
             }
         }


### PR DESCRIPTION
## Changes
- Added option to specify custom target folder for solution items.
- Fixed project names (assembly name was being used, not sure why?).
- Removed the root folder from the generated solution (I can revert this change or add an option for it if you want).
- Updated docs.

Also, I've been thinking if it wouldn't be easier to use a tree structure for the solution generation? Something like:

`SlnProject`
- `Guid ProjectTypeGuid { get; }`.
- `string Name { get; }`.
- `string FullPath { get; }`.
- `void GenerateSolutionFileText(TextWriter)`.

`SlnFolder : SlnProject`
- specify constant project type GUID.
- full path = name.
- override `GenerateSolutionFileText`.
- `IReadOnlyCollection<SlnItem> Items`.

`SlnFile`
- `IReadOnlyCollection<SlnProject> Projects { get; }`.