### PR TITLE
Fix support for cross targeting projects

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2018.2.1" />
-    <PackageReference Update="MSBuild.ProjectCreation" Version="1.2.8" />
+    <PackageReference Update="JetBrains.Annotations" Version="2019.1.1" />
+    <PackageReference Update="MSBuild.ProjectCreation" Version="1.2.11" />
     <PackageReference Update="Microsoft.Build" Version="15.9.20" ExcludeAssets="Runtime" />
     <PackageReference Update="Microsoft.Build.Framework" Version="15.9.20" ExcludeAssets="Runtime" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Update="Shouldly" Version="3.0.2" />
     <PackageReference Update="xunit" Version="2.4.1" />
     <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="2.3.38" />
-    <GlobalPackageReference Include="SlnGen" Version="2.1.5" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="2.3.138" />
+    <GlobalPackageReference Include="SlnGen" Version="2.1.7" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "Microsoft.Build.CentralPackageVersions": "2.0.1"
+    "Microsoft.Build.CentralPackageVersions": "2.0.26"
   }
 }

--- a/src/SlnGen.Build.Tasks.UnitTests/App.config
+++ b/src/SlnGen.Build.Tasks.UnitTests/App.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/SlnGen.Build.Tasks.UnitTests/SlnGen.Build.Tasks.UnitTests.csproj
+++ b/src/SlnGen.Build.Tasks.UnitTests/SlnGen.Build.Tasks.UnitTests.csproj
@@ -12,7 +12,18 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
 
+  <ItemGroup>
     <ProjectReference Include="..\SlnGen.Build.Tasks\SlnGen.Build.Tasks.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\SlnGen.Build.Tasks\build\*"
+             CopyToOutputDirectory="PreserveNewest"
+             Link="build\%(Filename)%(Extension)" />
+    <Content Include="..\SlnGen.Build.Tasks\buildCrossTargeting\*"
+             CopyToOutputDirectory="PreserveNewest"
+             Link="buildCrossTargeting\%(Filename)%(Extension)" />
   </ItemGroup>
 </Project>

--- a/src/SlnGen.Build.Tasks.UnitTests/SlnGenTests.cs
+++ b/src/SlnGen.Build.Tasks.UnitTests/SlnGenTests.cs
@@ -2,7 +2,10 @@
 //
 // Licensed under the MIT license.
 
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities.ProjectCreation;
 using Shouldly;
 using System;
 using System.Collections.Generic;
@@ -62,6 +65,87 @@ namespace SlnGen.Build.Tasks.UnitTests
             };
 
             ValidateParseCustomProjectTypeGuids(customProjectTypeGuids, ".foo", expectedProjectTypeGuid);
+        }
+
+        [Fact]
+        public void ProjectReferencesDeterminedInCrossTargetingBuild()
+        {
+            Dictionary<string, string> globlProperties = new Dictionary<string, string>
+            {
+                ["SlnGenLaunchVisualStudio"] = "false"
+            };
+
+            ProjectCollection projectCollection = new ProjectCollection(globlProperties);
+
+            ProjectCreator
+                .Create(Path.Combine(TestRootPath, "Directory.Build.props"))
+                .Save();
+            ProjectCreator
+                .Create(Path.Combine(TestRootPath, "Directory.Build.targets"))
+                .Import(Path.Combine(Environment.CurrentDirectory, "build", "SlnGen.targets"), condition: "'$(IsCrossTargetingBuild)' != 'true'")
+                .Import(Path.Combine(Environment.CurrentDirectory, "buildCrossTargeting", "SlnGen.targets"), condition: "'$(IsCrossTargetingBuild)' == 'true'")
+                .Save();
+
+            ProjectCreator projectA = ProjectCreator.Templates
+                .SdkCsproj(
+                    Path.Combine(TestRootPath, "ProjectA", "ProjectA.csproj"),
+                    targetFramework: "netcoreapp2.0")
+                .Save();
+
+            ProjectCreator projectB = ProjectCreator.Templates
+                .SdkCsproj(
+                    Path.Combine(TestRootPath, "ProjectB", "ProjectB.csproj"),
+                    targetFramework: "net46")
+                .Save();
+
+            ProjectCreator projectC = ProjectCreator.Templates
+                .SdkCsproj(
+                    Path.Combine(TestRootPath, "ProjectC", "ProjectC.csproj"),
+                    targetFramework: "net46")
+                .ItemProjectReference(projectA)
+                .Save();
+
+            ProjectCreator projectD = ProjectCreator.Templates
+                .SdkCsproj(
+                    Path.Combine(TestRootPath, "ProjectD", "ProjectD.csproj"),
+                    targetFramework: "net46")
+                .ItemProjectReference(projectB)
+                .ItemProjectReference(projectC)
+                .Save();
+
+            ProjectCreator
+                .Create(
+                    Path.Combine(TestRootPath, "ProjectC", "ProjectC.csproj"),
+                    sdk: "Microsoft.NET.Sdk",
+                    projectCollection: projectCollection,
+                    projectFileOptions: NewProjectFileOptions.None)
+                .PropertyGroup()
+                .Property("TargetFrameworks", "net46;netcoreapp2.0")
+                .Property("SlnGenAssemblyFile", Path.Combine(Environment.CurrentDirectory, "SlnGen.Build.Tasks.dll"))
+                .ItemProjectReference(projectA, condition: "'$(TargetFramework)' == 'netcoreapp2.0'")
+                .ItemProjectReference(projectB, condition: "'$(TargetFramework)' == 'net46'")
+                .ItemProjectReference(projectC, condition: "'$(TargetFramework)' == 'net46'")
+                .ItemProjectReference(projectD, condition: "'$(TargetFramework)' == 'net46'")
+                .Save()
+                .TryBuild("SlnGen", out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+
+            KeyValuePair<string, TargetResult> targetOutput = targetOutputs.ShouldHaveSingleItem();
+
+            targetOutput.Key.ShouldBe("SlnGen");
+
+            targetOutput.Value.Items
+                .Select(i => i.GetMetadata("OriginalItemSpec"))
+                .ShouldBe(
+                    new[]
+                    {
+                        projectA.FullPath,
+                        projectB.FullPath,
+                        projectC.FullPath,
+                        projectD.FullPath
+                    },
+                    ignoreOrder: true);
         }
 
         [Fact]

--- a/src/SlnGen.Build.Tasks/SlnGen.Build.Tasks.csproj
+++ b/src/SlnGen.Build.Tasks/SlnGen.Build.Tasks.csproj
@@ -34,8 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="build\SlnGen.targets" Pack="true" PackagePath="\build" />
-    <None Include="buildCrossTargeting\SlnGen.targets" Pack="true" PackagePath="\buildCrossTargeting" />
+    <None Include="build\*" Pack="true" PackagePath="\build" />
+    <None Include="buildCrossTargeting\*" Pack="true" PackagePath="\buildCrossTargeting" />
   </ItemGroup>
   
   <Target Name="_UpdatePackageId" BeforeTargets="$(PackDependsOn)" >

--- a/src/SlnGen.Build.Tasks/build/After.SlnGen.targets
+++ b/src/SlnGen.Build.Tasks/build/After.SlnGen.targets
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(CustomAfterSlnGenTargets)" Condition="'$(CustomAfterSlnGenTargets)' != '' and Exists('$(CustomAfterSlnGenTargets)')"/>
+</Project>

--- a/src/SlnGen.Build.Tasks/build/Before.SlnGen.targets
+++ b/src/SlnGen.Build.Tasks/build/Before.SlnGen.targets
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="$(CustomBeforeSlnGenTargets)" Condition="'$(CustomBeforeSlnGenTargets)' != '' and Exists('$(CustomBeforeSlnGenTargets)')"/>
+
+  <PropertyGroup Condition=" '$(SlnGenAssemblyFile)' == '' ">
+    <SlnGenAssemblyFile Condition=" '$(MSBuildRuntimeType)' == '' ">$(MSBuildThisFileDirectory)net45\SlnGen.Build.Tasks.dll</SlnGenAssemblyFile>
+    <SlnGenAssemblyFile Condition=" '$(MSBuildRuntimeType)' == 'Full' ">$(MSBuildThisFileDirectory)net46\SlnGen.Build.Tasks.dll</SlnGenAssemblyFile>
+    <SlnGenAssemblyFile Condition=" '$(MSBuildRuntimeType)' == 'Core' ">$(MSBuildThisFileDirectory)netstandard2.0\SlnGen.Build.Tasks.dll</SlnGenAssemblyFile>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <SlnGenGlobalProperties Condition=" '$(SlnGenGlobalProperties)' != '' ">DesignTimeBuild=true;BuildingProject=false;$(SlnGenGlobalProperties)</SlnGenGlobalProperties>
+    <SlnGenGlobalProperties Condition=" '$(SlnGenGlobalProperties)' == '' ">DesignTimeBuild=true;BuildingProject=false</SlnGenGlobalProperties>
+  </PropertyGroup>
+
+  <UsingTask TaskName="SlnGen" AssemblyFile="$(SlnGenAssemblyFile)" />
+</Project>

--- a/src/SlnGen.Build.Tasks/build/SlnGen.targets
+++ b/src/SlnGen.Build.Tasks/build/SlnGen.targets
@@ -1,18 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <Import Project="$(CustomBeforeSlnGenTargets)" Condition="'$(CustomBeforeSlnGenTargets)' != '' and Exists('$(CustomBeforeSlnGenTargets)')"/>
-
-  <PropertyGroup Condition=" '$(SlnGenAssemblyFile)' == '' ">
-    <SlnGenAssemblyFile Condition=" '$(MSBuildRuntimeType)' == '' ">$(MSBuildThisFileDirectory)net45\SlnGen.Build.Tasks.dll</SlnGenAssemblyFile>
-    <SlnGenAssemblyFile Condition=" '$(MSBuildRuntimeType)' == 'Full' ">$(MSBuildThisFileDirectory)net46\SlnGen.Build.Tasks.dll</SlnGenAssemblyFile>
-    <SlnGenAssemblyFile Condition=" '$(MSBuildRuntimeType)' == 'Core' ">$(MSBuildThisFileDirectory)netstandard2.0\SlnGen.Build.Tasks.dll</SlnGenAssemblyFile>
-  </PropertyGroup>
-  
-  <PropertyGroup>
-    <SlnGenGlobalProperties Condition=" '$(SlnGenGlobalProperties)' != '' ">DesignTimeBuild=true;BuildingProject=false;$(SlnGenGlobalProperties)</SlnGenGlobalProperties>
-    <SlnGenGlobalProperties Condition=" '$(SlnGenGlobalProperties)' == '' ">DesignTimeBuild=true;BuildingProject=false</SlnGenGlobalProperties>
-  </PropertyGroup>
+  <Import Project="Before.SlnGen.targets" />
 
   <Target Name="SlnGen"
           Condition=" '$(BuildingSolutionFile)' != 'true' Or '$(SolutionDir)' == '$(MSBuildProjectDirectory)\' "
@@ -42,8 +30,6 @@
 
   </Target>
 
-  <UsingTask TaskName="SlnGen" AssemblyFile="$(SlnGenAssemblyFile)" />
-
-  <Import Project="$(CustomAfterSlnGenTargets)" Condition="'$(CustomAfterSlnGenTargets)' != '' and Exists('$(CustomAfterSlnGenTargets)')"/>
+  <Import Project="After.SlnGen.targets" />
 
 </Project>

--- a/src/SlnGen.Build.Tasks/buildCrossTargeting/SlnGen.targets
+++ b/src/SlnGen.Build.Tasks/buildCrossTargeting/SlnGen.targets
@@ -1,4 +1,48 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\build\SlnGen.targets" />
+
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Before.SlnGen.targets" />
+
+  <Target Name="SlnGen"
+          DependsOnTargets="_ComputeTargetFrameworkItems"
+          Returns="@(InnerOutput)">
+
+    <MSBuild Projects="@(_InnerBuildProjects)"
+             Condition="'@(_InnerBuildProjects)' != '' And $(BuildingSolutionFile) != 'true'"
+             Targets="ResolveProjectReferences"
+             Properties="DesignTimeBuild=true"
+             BuildInParallel="$(BuildInParallel)"
+             SkipNonexistentTargets="true"
+             SkipNonexistentProjects="true">
+      <Output ItemName="InnerOutput" TaskParameter="TargetOutputs" />
+    </MSBuild>
+
+    <ItemGroup>
+      <_MSBuildProjectReferenceExistent Include="%(InnerOutput.OriginalItemSpec)" Condition="Exists('%(InnerOutput.OriginalItemSpec)')" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <SlnGenSolutionFileFullPath Condition=" '$(SlnGenSolutionFileFullPath)' == '' And '$(BuildingSolutionFile)' == 'true' ">$(SolutionPath)</SlnGenSolutionFileFullPath>
+    </PropertyGroup>
+
+    <SlnGen
+      BuildingSolutionFile="$(BuildingSolutionFile)"
+      CollectStats="$([MSBuild]::ValueOrDefault('$(SlnGenCollectStats)', 'false'))"
+      CustomProjectTypeGuids="@(SlnGenCustomProjectTypeGuid)"
+      DevEnvFullPath="$(SlnGenDevEnvFullPath)"
+      Folders="$([MSBuild]::ValueOrDefault('$(SlnGenFolders)', 'true'))"
+      GlobalProperties="$(SlnGenGlobalProperties)"
+      GlobalPropertiesToRemove="$(SlnGenGlobalPropertiesToRemove)"
+      InheritGlobalProperties="$([MSBuild]::ValueOrDefault('$(SlnGenInheritGlobalProperties)', 'true'))"
+      ProjectFullPath="$(MSBuildProjectFullPath)"
+      ProjectReferences="@(_MSBuildProjectReferenceExistent)"
+      ShouldLaunchVisualStudio="$([MSBuild]::ValueOrDefault('$(SlnGenLaunchVisualStudio)', 'true'))"
+      SolutionFileFullPath="$(SlnGenSolutionFileFullPath)"
+      SolutionItems="@(SlnGenSolutionItem)"
+      ToolsVersion="$([MSBuild]::ValueOrDefault('$(SlnGenToolsVersion)', '$(MSBuildToolsVersion)'))"
+      UseShellExecute="$([MSBuild]::ValueOrDefault('$(SlnGenUseShellExecute)', 'true'))"
+    />
+  </Target>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\build\After.SlnGen.targets" />
 </Project>


### PR DESCRIPTION
SDK-style projects dispatch inner builds to resolve project references.  This change updates the SlnGen target when running in cross targeting mode to dispatch the inner builds to get the project references.

Fixes #50