### PR TITLE
Fix InvalidOperationException when generating a solution for a single project

### DIFF
--- a/src/SlnGen.Build.Tasks/Internal/SlnFile.cs
+++ b/src/SlnGen.Build.Tasks/Internal/SlnFile.cs
@@ -118,7 +118,7 @@ namespace SlnGen.Build.Tasks.Internal
 
             SlnHierarchy hierarchy = null;
 
-            if (useFolders)
+            if (useFolders && _projects.Any(i => !i.IsMainProject))
             {
                 hierarchy = new SlnHierarchy(_projects);
 


### PR DESCRIPTION
Single projects should not attempt to generate hierarchy.

Fixes #56 