### PR TITLE
SlnHierarchy: Properly handle directory separator.

### DIFF
--- a/src/SlnGen.Build.Tasks.UnitTests/SlnHierarchyTests.cs
+++ b/src/SlnGen.Build.Tasks.UnitTests/SlnHierarchyTests.cs
@@ -22,10 +22,10 @@ namespace SlnGen.Build.Tasks.UnitTests
 
             List<SlnProject> projects = new List<SlnProject>
             {
-                new SlnProject(@"D:\foo\bar\baz\baz.csproj", "baz", Guid.NewGuid(), SlnProject.DefaultLegacyProjectTypeGuid, configurations, platforms, false, isDeployable: false),
-                new SlnProject(@"D:\foo\bar\baz1\baz1.csproj", "baz1", Guid.NewGuid(), SlnProject.DefaultLegacyProjectTypeGuid, configurations, platforms, false, isDeployable: false),
-                new SlnProject(@"D:\foo\bar\baz2\baz2.csproj", "baz2", Guid.NewGuid(), SlnProject.DefaultLegacyProjectTypeGuid, configurations, platforms, false, isDeployable: false),
-                new SlnProject(@"D:\foo\bar1\bar1.csproj", "bar1", Guid.NewGuid(), SlnProject.DefaultLegacyProjectTypeGuid, configurations, platforms, false, isDeployable: false),
+                new SlnProject(@"D:\zoo\foo\bar\baz\baz.csproj", "baz", Guid.NewGuid(), SlnProject.DefaultLegacyProjectTypeGuid, configurations, platforms, false, isDeployable: false),
+                new SlnProject(@"D:\zoo\foo\bar\baz1\baz1.csproj", "baz1", Guid.NewGuid(), SlnProject.DefaultLegacyProjectTypeGuid, configurations, platforms, false, isDeployable: false),
+                new SlnProject(@"D:\zoo\foo\bar\baz2\baz2.csproj", "baz2", Guid.NewGuid(), SlnProject.DefaultLegacyProjectTypeGuid, configurations, platforms, false, isDeployable: false),
+                new SlnProject(@"D:\zoo\foo\bar1\bar1.csproj", "bar1", Guid.NewGuid(), SlnProject.DefaultLegacyProjectTypeGuid, configurations, platforms, false, isDeployable: false),
             };
 
             SlnHierarchy hierarchy = new SlnHierarchy(projects);
@@ -33,12 +33,12 @@ namespace SlnGen.Build.Tasks.UnitTests
             hierarchy.Folders.Select(i => i.FullPath)
                 .ShouldBe(new[]
                 {
-                    @"D:\foo\bar\baz",
-                    @"D:\foo\bar\baz1",
-                    @"D:\foo\bar\baz2",
-                    @"D:\foo\bar",
-                    @"D:\foo\bar1",
-                    @"D:\foo",
+                    @"D:\zoo\foo\bar\baz",
+                    @"D:\zoo\foo\bar\baz1",
+                    @"D:\zoo\foo\bar\baz2",
+                    @"D:\zoo\foo\bar",
+                    @"D:\zoo\foo\bar1",
+                    @"D:\zoo\foo",
                 });
 
             foreach (SlnProject project in projects)

--- a/src/SlnGen.Build.Tasks/Internal/SlnHierarchy.cs
+++ b/src/SlnGen.Build.Tasks/Internal/SlnHierarchy.cs
@@ -69,9 +69,9 @@ namespace SlnGen.Build.Tasks.Internal
             {
                 if (commonPath.Length == 0 && paths.All(str => str.StartsWith(pathSegment)))
                 {
-                    commonPath = pathSegment;
+                    commonPath = pathSegment + Path.DirectorySeparatorChar;
                 }
-                else if (paths.All(str => str.StartsWith(nextPath = $"{commonPath}{Path.DirectorySeparatorChar}{pathSegment}{Path.DirectorySeparatorChar}")))
+                else if (paths.All(str => str.StartsWith(nextPath = $"{commonPath}{pathSegment}{Path.DirectorySeparatorChar}")))
                 {
                     commonPath = nextPath;
                 }


### PR DESCRIPTION
Each iteration over a path segment added path separator before and after,
yielding doubled path separator and tricking the hierarchy resolution into
believing that all folders up to the drive letter are part of the solution, no
matter what.

The logic in GetRootFolder is fixed, and the test updated so that this case is
properly detected.