### PR TITLE
Fixed parent linking and root parent linking

### DIFF
--- a/src/SlnGen.Build.Tasks.UnitTests/SlnFileTests.cs
+++ b/src/SlnGen.Build.Tasks.UnitTests/SlnFileTests.cs
@@ -61,6 +61,31 @@ namespace SlnGen.Build.Tasks.UnitTests
         }
 
         [Fact]
+        public void WithFolders()
+        {
+            SlnProject[] projects =
+            {
+                new SlnProject(GetTempFileName(), "ProjectA", new Guid("C95D800E-F016-4167-8E1B-1D3FF94CE2E2"), new Guid("88152E7E-47E3-45C8-B5D3-DDB15B2F0435"), new[] { "Debug" }, new[] { "x64" }, isMainProject: true, isDeployable: false),
+                new SlnProject(GetTempFileName(), "ProjectB", new Guid("EAD108BE-AC70-41E6-A8C3-450C545FDC0E"), new Guid("F38341C3-343F-421A-AE68-94CD9ADCD32F"), new[] { "Debug" }, new[] { "x64" }, isMainProject: false, isDeployable: false),
+                new SlnProject(GetTempFileName(), "ProjectC", new Guid("00C5B0C0-E19C-48C5-818D-E8CD4FA2A915"), new Guid("F38341C3-343F-421A-AE68-94CD9ADCD32F"), new[] { "Debug" }, new[] { "x64" }, isMainProject: false, isDeployable: false),
+            };
+
+            var action = new Action<SlnProject, ProjectInSolution>((s, p) =>
+            {
+                if (s.IsMainProject)
+                {
+                    p.ParentProjectGuid.ShouldBeNull();
+                }
+                else
+                {
+                    p.ParentProjectGuid.ShouldNotBeNull();
+                }
+            });
+
+            ValidateProjectInSolution(action, projects, true);
+        }
+
+        [Fact]
         public void SaveToCustomLocationCreatesDirectory()
         {
             DirectoryInfo directoryInfo = new DirectoryInfo(Path.Combine(TestRootPath, "1", "2", "3"));

--- a/src/SlnGen.Build.Tasks/Internal/SlnFile.cs
+++ b/src/SlnGen.Build.Tasks/Internal/SlnFile.cs
@@ -133,14 +133,17 @@ namespace SlnGen.Build.Tasks.Internal
             {
                 writer.WriteLine(@"	GlobalSection(NestedProjects) = preSolution");
 
-                foreach (SlnFolder folder in hierarchy.Folders.Where(i => i.Parent != null))
+                foreach (SlnFolder folder in hierarchy.Folders)
                 {
                     foreach (SlnProject project in folder.Projects)
                     {
                         writer.WriteLine($@"		{project.ProjectGuid.ToSolutionString()} = {folder.FolderGuid.ToSolutionString()}");
                     }
 
-                    writer.WriteLine($@"		{folder.FolderGuid.ToSolutionString()} = {folder.Parent.FolderGuid.ToSolutionString()}");
+                    if (folder.Parent != null)
+                    {
+                        writer.WriteLine($@"		{folder.FolderGuid.ToSolutionString()} = {folder.Parent.FolderGuid.ToSolutionString()}");
+                    }
                 }
 
                 writer.WriteLine("	EndGlobalSection");

--- a/src/SlnGen.Build.Tasks/Internal/SlnFile.cs
+++ b/src/SlnGen.Build.Tasks/Internal/SlnFile.cs
@@ -133,7 +133,7 @@ namespace SlnGen.Build.Tasks.Internal
             {
                 writer.WriteLine(@"	GlobalSection(NestedProjects) = preSolution");
 
-                foreach (SlnFolder folder in hierarchy.Folders.Where(x => x.Parent != null))
+                foreach (SlnFolder folder in hierarchy.Folders.Where(i => i.Parent != null))
                 {
                     foreach (SlnProject project in folder.Projects)
                     {

--- a/src/SlnGen.Build.Tasks/Internal/SlnFile.cs
+++ b/src/SlnGen.Build.Tasks/Internal/SlnFile.cs
@@ -133,17 +133,14 @@ namespace SlnGen.Build.Tasks.Internal
             {
                 writer.WriteLine(@"	GlobalSection(NestedProjects) = preSolution");
 
-                foreach (SlnFolder folder in hierarchy.Folders)
+                foreach (SlnFolder folder in hierarchy.Folders.Where(x => x.Parent != null))
                 {
                     foreach (SlnProject project in folder.Projects)
                     {
                         writer.WriteLine($@"		{project.ProjectGuid.ToSolutionString()} = {folder.FolderGuid.ToSolutionString()}");
                     }
 
-                    if (folder.Parent != null)
-                    {
-                        writer.WriteLine($@"		{folder.FolderGuid.ToSolutionString()} = {folder.Parent.FolderGuid.ToSolutionString()}");
-                    }
+                    writer.WriteLine($@"		{folder.FolderGuid.ToSolutionString()} = {folder.Parent.FolderGuid.ToSolutionString()}");
                 }
 
                 writer.WriteLine("	EndGlobalSection");

--- a/src/SlnGen.Build.Tasks/Internal/SlnHierarchy.cs
+++ b/src/SlnGen.Build.Tasks/Internal/SlnHierarchy.cs
@@ -145,6 +145,7 @@ namespace SlnGen.Build.Tasks.Internal
             if (!_rootFolder.Folders.Contains(childFolder))
             {
                 _rootFolder.Folders.Add(childFolder);
+                childFolder.Parent = _rootFolder;
             }
         }
 


### PR DESCRIPTION
Fixed child folder setting to the highest level root folder, also fixed linking between parent folder and child project in the generated sln file as this was missing in some cases