### PR TITLE
Change ProjectConfigurationPlatforms to be postSolution

### DIFF
--- a/src/SlnGen.Build.Tasks/Internal/SlnFile.cs
+++ b/src/SlnGen.Build.Tasks/Internal/SlnFile.cs
@@ -164,7 +164,7 @@ namespace SlnGen.Build.Tasks.Internal
 
             writer.WriteLine("	EndGlobalSection");
 
-            writer.WriteLine("	GlobalSection(ProjectConfigurationPlatforms) = preSolution");
+            writer.WriteLine("	GlobalSection(ProjectConfigurationPlatforms) = postSolution");
             foreach (SlnProject project in _projects)
             {
                 foreach (string configuration in allConfigurations)


### PR DESCRIPTION
When running SlnGen on a repository with a mix of .Net Standard and .Net framework the solution file generated would hang on load. After binary searching the changes I found that the solution file generated by Visual Studio has ProjectConfigurationPlatforms as postSolution. Making this one change causes the solution to properly load. This fixes issue #71